### PR TITLE
6nYH14Af/3635-releasing-speech-to-text

### DIFF
--- a/.env
+++ b/.env
@@ -3,7 +3,7 @@ OPENAI_API_KEY="YOUR_OPENAI_API_HERE"
 #You can use custom prompt to Whisper, if you don't want, keep it blank
 CUSTOM_PROMPT="Do not translate"
 #Define the keyboard shortcut to activate/deactivate speech-to-text
-KEYBOARD_BINDING="cmd+\\"
+KEYBOARD_BINDING="alt_l+\\"
 #Use true or false to keep app on top
 KEEP_ON_TOP=true
 #Resend button

--- a/.env
+++ b/.env
@@ -1,8 +1,14 @@
 #Replace YOUR_OPENAI_API_HERE by your OpenAI API Key
 OPENAI_API_KEY="YOUR_OPENAI_API_HERE"
 #You can use custom prompt to Whisper, if you don't want, keep it blank
-CUSTOM_PROMPT="Forget previous input. Transcribe in detected language, don't translate!"
+CUSTOM_PROMPT="Do not translate"
 #Define the keyboard shortcut to activate/deactivate speech-to-text
-KEYBOARD_BINDING="control+\\"
+KEYBOARD_BINDING="cmd+\\"
 #Use true or false to keep app on top
 KEEP_ON_TOP=true
+#Resend button
+RESEND_BUTTON=true
+#Auto-detect language
+AUTO_DETECT_LANGUAGE=false
+#If AUTO_DETECT_LANGUAGE is set to false, you can choose 2 languages to toggle from
+LANGUAGES='en,fr,pt'

--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ git clone https://github.com/zumub/speech-to-text-whisper
   OPENAI_API_KEY="YOUR_OPENAI_API_HERE"
   CUSTOM_PROMPT=""
   KEYBOARD_BINDING="control+\\"
+  KEEP_ON_TOP=true
+  RESEND_BUTTON=true
+  AUTO_DETECT_LANGUAGE=false
+  LANGUAGES='en,fr,pt'
   ```
 
   
@@ -136,12 +140,30 @@ git clone https://github.com/zumub/speech-to-text-whisper
 	 ```
 	> [!NOTE] 
 	> - For more information or troubleshooting during installation, you can visit the [Homebrew](https://brew.sh/) and [FFmpeg](https://ffmpeg.org/) official documentation.
-### Step 4: Install project dependencies
+### Step 4: Install PortAudio:
+- To download PortAudio manually: [PortAudio downloads](https://files.portaudio.com/download.html)
+- To install with terminal: 
+  - Install **Homebrew** (Package Manager)
+    ```bash
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    ```
+  - Install **PortAudio**
+	  ```bash
+	 brew install portaudio
+	 ```
+  - Confirm the installation and check the PortAudio version:
+	  ```bash
+	 brew info portaudio
+	 ```
+	> [!NOTE] 
+	> - For more information or troubleshooting during installation, you can visit the [Homebrew](https://brew.sh/) and [PortAudio](https://www.portaudio.com/) official documentation.
+
+### Step 5: Install project dependencies
 - Open terminal in project directory and run the following command:
   ```bash
   pip3 install -r requirements.txt
   ```
-### Step 5: Create an executeable file
+### Step 6: Create an executeable file
 > [!IMPORTANT] 
 > PyInstaller is required to create an executeable file. .
 - Open terminal and run the following command:
@@ -169,6 +191,10 @@ git clone https://github.com/zumub/speech-to-text-whisper
   OPENAI_API_KEY="YOUR_OPENAI_API_HERE"
   CUSTOM_PROMPT=""
   KEYBOARD_BINDING="control+\\"
+  KEEP_ON_TOP=true
+  RESEND_BUTTON=true
+  AUTO_DETECT_LANGUAGE=false
+  LANGUAGES='en,fr,pt'
   ```
 
 ## Usage
@@ -176,6 +202,7 @@ git clone https://github.com/zumub/speech-to-text-whisper
 - Activate the application using the configured hotkey to start transcribing.
 - Speak clearly and once done, use the hotkey again to stop the transcription.
 - Review the Transcription: The transcribed text will be automatically inserted at the cursor position.
+- To translate into specific language, use AUTO_DETECT_LANGUAGE=false and set 'LANGUAGES' in .env
 
 # Support Zumub
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-pyaudio
-python-dotenv
-openai
-pyperclip
-keyboard
-global_hotkeys
-tk
+pyaudio==0.2.13
+python-dotenv==1.0.0
+openai==0.28.1
+pyperclip==1.8.2
+pynput==1.7.6
+tk==0.1.0
+pyautogui==0.9.54

--- a/speech2text.py
+++ b/speech2text.py
@@ -140,19 +140,15 @@ def get_transcript(app):
         app.color_indicator.config(bg='green')
 
 def paste_text():
+    keyboard = Controller()
     if platform.system() == "Windows":
-        with Controller() as keyboard:
-            keyboard.press(Key.ctrl)
+        with keyboard.pressed(Key.ctrl):
             keyboard.press('v')
             keyboard.release('v')
-            keyboard.release(Key.ctrl)
     else:
-        with Listener(on_press=None, on_release=None) as listener:
-            with Controller() as keyboard:
-                keyboard.press(Key.cmd)
-                keyboard.press('v')
-                keyboard.release('v')
-                keyboard.release(Key.cmd)
+        with keyboard.pressed(Key.cmd):
+            keyboard.press('v')
+            keyboard.release('v')
 
 class AudioRecorder:
     def __init__(self, root):


### PR DESCRIPTION
- [X] Updated script for macos
- [X] Script tested on macos and windows
- [X] Readme file is updated
- [X] 'AUTO_DETECT_LANGUAGE' and 'RESEND_BUTTON' is added

- Auto paste text don't work in macos, it copies text to clipboard, and user can press Ctrl+V to paste text.
- Some hotkey combinations don't work. Tested 'Alt_l+\\' works for windows and 'cmd+\\' works on mac.